### PR TITLE
fix for #336

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -463,7 +463,7 @@
                 else {
                     set($(e.target).closest(".sp-thumb-el").data("color"));
                     move();
-                    updateOriginalInput(true);
+                    updateOriginalInput(false);
                     if (opts.hideAfterPaletteSelect) {
                       hide();
                     }


### PR DESCRIPTION
Don't fireCallback when calling updateOriginalInput after clicking palette color, according to specs: " Only happens when the input is closed or the 'Choose' button is clicked."
